### PR TITLE
fix: Check for dynamic cubemap define before use

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2268,7 +2268,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace
 
 	float4 color = 0;
 
-#	if defined(TRUE_PBR)
+#	if defined(TRUE_PBR) && defined(DYNAMIC_CUBEMAPS)
 	{
 		float3 directLightsDiffuseInput = diffuseColor * baseColor.xyz;
 		[branch] if ((PBRFlags & TruePBR_ColoredCoat) != 0)


### PR DESCRIPTION
Fixes true pbr trying to use dyn cubemaps in permutations that have DYNAMIC_CUBEMAP undefined. This seems to happen in permutations with LODOBJECTS define.